### PR TITLE
Add simple login with hardcoded credentials

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,8 +6,11 @@ import {
   CssBaseline,
 } from "@mui/material";
 import { OperadoraProvider } from "./context/OperadoraContext";
+import { AuthProvider } from "./context/AuthContext";
 import Home from "./pages/Home";
 import Documentos from "./pages/Documentos";
+import Login from "./pages/Login";
+import PrivateRoute from "./components/PrivateRoute";
 
 // Updated theme - adjust these colors based on your logo
 const theme = createTheme({
@@ -54,14 +57,31 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <OperadoraProvider>
-        <Router>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/documentos" element={<Documentos />} />
-          </Routes>
-        </Router>
-      </OperadoraProvider>
+      <AuthProvider>
+        <OperadoraProvider>
+          <Router>
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route
+                path="/"
+                element={
+                  <PrivateRoute>
+                    <Home />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/documentos"
+                element={
+                  <PrivateRoute>
+                    <Documentos />
+                  </PrivateRoute>
+                }
+              />
+            </Routes>
+          </Router>
+        </OperadoraProvider>
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/AppBarComponent.js
+++ b/src/components/AppBarComponent.js
@@ -21,9 +21,11 @@ import {
   Menu as MenuIcon,
   Assessment,
   InsertDriveFile,
-  Close
+  Close,
+  Logout as LogoutIcon
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 const LogoImage = styled('img')({
   height: '80px',
@@ -35,6 +37,7 @@ const LogoImage = styled('img')({
 const AppBarComponent = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { logout } = useAuth();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -102,6 +105,14 @@ const AppBarComponent = () => {
                   {item.text}
                 </Button>
               ))}
+              <Button
+                color="inherit"
+                startIcon={<LogoutIcon />}
+                onClick={logout}
+                sx={{ textTransform: 'none' }}
+              >
+                Sair
+              </Button>
             </Box>
           )}
 
@@ -181,6 +192,19 @@ const AppBarComponent = () => {
         </List>
 
         <Box sx={{ mt: 'auto', p: 2, borderTop: '1px solid rgba(255, 255, 255, 0.1)' }}>
+          <Button
+            fullWidth
+            variant="contained"
+            color="secondary"
+            startIcon={<LogoutIcon />}
+            onClick={() => {
+              logout();
+              setMobileMenuOpen(false);
+            }}
+            sx={{ mb: 2 }}
+          >
+            Sair
+          </Button>
           <Typography variant="body2" sx={{ opacity: 0.7, textAlign: 'center' }}>
             Aplicativo Delator
           </Typography>

--- a/src/components/PrivateRoute.jsx
+++ b/src/components/PrivateRoute.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const PrivateRoute = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+export default PrivateRoute;

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext();
+
+export const useAuth = () => {
+  return useContext(AuthContext);
+};
+
+export const AuthProvider = ({ children }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(() => {
+    return localStorage.getItem('isAuthenticated') === 'true';
+  });
+
+  const login = (username, password) => {
+    // Hardcoded credentials
+    const validUser = 'admin';
+    const validPass = 'senha123';
+    if (username === validUser && password === validPass) {
+      setIsAuthenticated(true);
+      localStorage.setItem('isAuthenticated', 'true');
+      return true;
+    }
+    return false;
+  };
+
+  const logout = () => {
+    setIsAuthenticated(false);
+    localStorage.removeItem('isAuthenticated');
+  };
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TextField, Button, Paper, Typography, Box } from '@mui/material';
+import { useAuth } from '../context/AuthContext';
+
+const Login = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const success = login(username, password);
+    if (success) {
+      navigate('/');
+    } else {
+      setError('Usuário ou senha inválidos');
+    }
+  };
+
+  return (
+    <Box sx={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f5f5f5' }}>
+      <Paper sx={{ p: 4, width: 320 }}>
+        <Typography variant="h5" sx={{ mb: 2, textAlign: 'center' }}>
+          Login
+        </Typography>
+        <form onSubmit={handleSubmit}>
+          <TextField
+            fullWidth
+            label="Usuário"
+            margin="normal"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <TextField
+            fullWidth
+            type="password"
+            label="Senha"
+            margin="normal"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          {error && (
+            <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+              {error}
+            </Typography>
+          )}
+          <Button variant="contained" fullWidth type="submit" sx={{ mt: 2 }}>
+            Entrar
+          </Button>
+        </form>
+      </Paper>
+    </Box>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- create AuthContext and PrivateRoute
- add Login page and protect existing routes
- add logout buttons

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6061cac48328bce6c57986e1fc5f